### PR TITLE
Ship the Flexy page template with the module

### DIFF
--- a/templates/frontOffice/flexy/page.html.twig
+++ b/templates/frontOffice/flexy/page.html.twig
@@ -1,0 +1,25 @@
+{% extends 'base.html.twig' %}
+
+{% set pageData = getPageData() %}
+{% set pageHTML = getTheliaBLocksRenderedContent(pageData.getVirtualColumn('block_group_content')|default('')) %}
+{% set img = getImagesData({
+	source_type: 'page',
+	source_id: pageData.id,
+	filters: 'default'
+}) %}
+
+{% block og_image %}{{ ((img|first)?.sources|first)?.url ?: parent()  }}{% endblock %}
+{% block og_type %}article{% endblock %}
+
+{% block body %}
+    {{ include('@components/Layout/Subheader/ContentPage/SubheaderContentPage.html.twig', {title: pageData.title, description: pageData.chapo|raw}) }}
+
+    <div class="px-[25px] lg:pr-[225px] lg:pl-[250px] xl:pr-[325px] xl:pl-[350px] flex gap-[173px] mt-[25px] lg:mt-[54px] mb-[80px] lg:mb-[120px]">
+        <article class="wysiwyg">
+            {{ pageData.description|raw }}
+
+            {{ pageHTML|raw }}
+        </article>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
### Why

The Flexy theme shipped `page.html.twig`, the view template for this module's
`page` view. The theme does not require the module, so on a stock Flexy install
the template is a 500 on every request that reaches it — `getPageData()` is
registered by `Page\Twig\PageTwigExtension` and nothing else defines it
(thelia/thelia#3590). Twig resolves functions at compile time, so the theme
cannot guard the call; the template belongs here.

### What

`templates/frontOffice/flexy/page.html.twig`, byte for byte what the theme
carried. `TheliaKernel::getModuleTemplateDirs()` registers every module
`templates/frontOffice/<template-name>` directory, and `TwigParser` adds the ones
matching the active template, so the parser resolves `page.html.twig` from here
when Flexy is the front template — the same mechanism TheliaBlocks already uses
for its `modern` directory.

### Verified

On a fresh Thelia 3 install with demo data and Flexy active, the file was placed
in an active module's `templates/frontOffice/flexy/` directory and `/page`
compiled it from there instead of the theme, proving the resolution path. The
full render with real page data was not exercised: the Page module is not
installed on that bench.

The companion removal is thelia-templates/flexy#134. Merge order matters: a
Flexy release that drops the template before this one ships leaves Page + Flexy
sites without their page template.
