### PR TITLE
fix: fall back to the generic page template instead of crashing

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <authors>
         <author>
             <name>Damien Foulhoux</name>

--- a/Service/PageService.php
+++ b/Service/PageService.php
@@ -10,6 +10,7 @@ use Page\Model\PageQuery;
 use Page\Page;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\Parser\ParserResolver;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateHelperInterface;
@@ -128,7 +129,12 @@ class PageService
 
     public function templateExist(string $templateName) : bool {
         $path = $this->templateHelper->getActiveFrontTemplate()->getAbsolutePath();
-        $this->parser = $this->parserResolver->getParser($path, $templateName);
+
+        try {
+            $this->parser = $this->parserResolver->getParser($path, $templateName);
+        } catch (ResourceNotFoundException) {
+            return false;
+        }
 
         $filePath = $path . DS . $templateName . '.' . $this->parser->getFileExtension();
 


### PR DESCRIPTION
templateExist() called ParserResolver::getParser() to probe whether a per-page-code or per-page-type template override exists, but getParser() throws ResourceNotFoundException on a miss instead of returning null. That exception was never caught, so any page (or ancestor page in the tree) whose code or page type had no matching page-<name> template crashed the whole page view with a 500 instead of falling through to the theme's generic page template.